### PR TITLE
ngx-http-log-json: variables

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Changes with ngx-http-log-json 0.0.4                                 4 Apr 2017
+    *) module variable $http_log_json_req_headers
+    *) module variable $http_log_json_resp_headers
+    *) module variable $http_log_json_req_body
+    *) local directive http_log_json_req_body_limit
+
 Changes with ngx-http-log-json 0.0.3                                31 Mar 2017
 
     *) allow to write to multiple destination with differente formats

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ For this, known or previously setted variables, can be used by using the '$' bef
 
 Common HTTP nginx builtin variables like $uri, or any other variable set by other handler modules can be used.
 
+Additional variables are provided by this module. See the available variables below at [Variables section](#variables).
+
 The output is sent to the location specified by the first http_log_json_format argument.
 The possible output locations are:
 
@@ -214,41 +216,94 @@ The format to use when writing to output destination.
 
 ---
 
-* Syntax: **"http_log_json_kafka_compression** _compression_codec_;
+* Syntax: **http_log_json_kafka_compression** _compression_codec_;
 * Default: snappy
 * Context: http main
 
 ---
 
-* Syntax: **"http_log_json_kafka_log_level** _numeric_log_level_;
+* Syntax: **http_log_json_kafka_log_level** _numeric_log_level_;
 * Default: 6
 * Context: http main
 
 ---
 
-* Syntax: **"http_log_json_kafka_max_retries** _numeric_;
+* Syntax: **http_log_json_kafka_max_retries** _numeric_;
 * Default: 0
 * Context: http main
 
 ---
 
-* Syntax: **"http_log_json_kafka_buffer_max_messages** _numeric_;
+* Syntax: **http_log_json_kafka_buffer_max_messages** _numeric_;
 * Default: 100000
 * Context: http main
 
 ---
 
-* Syntax: **"http_log_json_kafka_backoff_ms** _numeric_;
+* Syntax: **http_log_json_kafka_backoff_ms** _numeric_;
 * Default: 10
 * Context: http main
 
 ---
 
-* Syntax: **"http_log_json_kafka_partition** _partition_;
+* Syntax: **http_log_json_kafka_partition** _partition_;
 * Default: RD_KAFKA_PARTITION_UA
 * Context: http local
 
+---
 
+* Syntax: **http_log_json_req_body_limit** _size_;
+* Default: 512
+* Context: local
+
+Limits the body size to log.
+Argument is a size string. May be 1k or 1M, but avoid this!
+
+### Variables
+
+#### $http_log_json_req_headers;
+
+Creates a json object with all request headers.
+
+Example:
+
+```
+    "req": {
+        "headers": {
+            "Host": "localhost",
+            "User-Agent": "curl/7.52.1",
+            "Accept": "*/*"
+        }
+    }
+```
+
+#### $http_log_json_req_body;
+
+Log request body encoded as base64.
+It requires proxy_pass configuration at logging location.
+
+Example:
+
+```
+    "req": {
+        "body": "Zm9v"
+    }
+```
+#### $http_log_json_resp_headers;
+
+Creates a json object with available response headers.
+
+Example:
+
+```
+        resp": {
+        "headers": {
+          "Last-Modified": "Sat, 01 Apr 2017 13:34:28 GMT",
+          "ETag": "\"58dfac64-12\"",
+          "X-Foo": "bar",
+          "Accept-Ranges": "bytes"
+        }
+```
 
 ### Build
 
@@ -368,9 +423,9 @@ Percentage of the requests served within a certain time (ms)
   99%      1
  100%    115 (longest request)
 
-real	1m36.057s
-user	0m5.390s
-sys	1m22.040s
+real   1m36.057s
+user   0m5.390s
+sys   1m22.040s
 
 $ wc -l /tmp/1M.log
 1000000 /tmp/1M.log 
@@ -435,7 +490,8 @@ Percentage of the requests served within a certain time (ms)
   99%      2
  100%   1022 (longest request)
 
-real	1m43.328s
-user	0m5.770s
-sys	1m21.380s
+real   1m43.328s
+user   0m5.770s
+sys   1m21.380s
 ```
+

--- a/config
+++ b/config
@@ -3,10 +3,17 @@ ngx_module_incs=$ngx_addon_dir/src
 
 HTTP_MODULES="$HTTP_MODULES ngx_http_log_json_module"
 
+HTTP_FILTER_MODULES="$HTTP_FILTER_MODULES ngx_http_log_json_filter_module"
+
 CORE_INCS="$CORE_INCS $ngx_module_incs"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
- $ngx_addon_dir/src/ngx_http_log_json_kafka.c  \
- $ngx_addon_dir/src/ngx_http_log_json_str.c    \
- $ngx_addon_dir/src/ngx_http_log_json_module.c \
- $ngx_addon_dir/src/ngx_http_log_json_text.c   "
+
+NGX_ADDON_SRCS="$NGX_ADDON_SRCS                         \
+ $ngx_addon_dir/src/ngx_http_log_json_kafka.c           \
+ $ngx_addon_dir/src/ngx_http_log_json_str.c             \
+ $ngx_addon_dir/src/ngx_http_log_json_text.c            \
+ $ngx_addon_dir/src/ngx_http_log_json_variables.c       \
+ $ngx_addon_dir/src/ngx_http_log_json_module.c          \
+ $ngx_addon_dir/src/ngx_http_log_json_filter_module.c   \
+ "
+
 CORE_LIBS="$CORE_LIBS -ljansson -lrdkafka"

--- a/docker/nginx-http-log-json/Dockerfile
+++ b/docker/nginx-http-log-json/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer "fooinha@gmail.com"
 # Build arguments
 ARG DEBIAN_REPO_HOST=httpredir.debian.org
 ARG GIT_LOCATION=https://github.com/fooinha/nginx-http-log-json.git
-ARG GIT_BRANCH=feature/0.0.3/module/lod
+ARG GIT_BRANCH=master
 
 # Mirror to my location
 RUN echo "deb http://${DEBIAN_REPO_HOST}/debian sid main" > /etc/apt/sources.list

--- a/src/ngx_http_log_json_filter_module.c
+++ b/src/ngx_http_log_json_filter_module.c
@@ -1,0 +1,355 @@
+/*
+ * Copyright (C) 2017 Paulo Pacheco
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include <ngx_log.h>
+
+#include "ngx_http_log_json_module.h"
+#include "ngx_http_log_json_variables.h"
+
+#define HTTP_LOG_JSON_REQ_BODY_LIMIT_DEFAULT 512
+
+struct ngx_http_log_json_req_body_s {
+    ngx_http_request_t                       *r;
+    ngx_str_t                                 payload;
+    ngx_queue_t                               queue;
+};
+
+typedef struct ngx_http_log_json_req_body_s ngx_http_log_json_req_body_t;
+typedef struct ngx_http_log_json_resp_headers_s
+    ngx_http_log_json_resp_headers_t;
+
+/* main config state */
+struct ngx_http_log_json_filter_main_conf_s {
+};
+
+/* location config */
+struct ngx_http_log_json_filter_loc_conf_s {
+    size_t                req_body_limit;
+};
+
+typedef struct ngx_http_log_json_filter_main_conf_s
+    ngx_http_log_json_filter_main_conf_t;
+
+typedef struct ngx_http_log_json_filter_loc_conf_s
+    ngx_http_log_json_filter_loc_conf_t;
+
+static void *
+ngx_http_log_json_filter_create_main_conf(ngx_conf_t *cf);
+
+static void *
+ngx_http_log_json_filter_create_loc_conf(ngx_conf_t *cf);
+
+static ngx_int_t
+ngx_http_log_json_filter_init(ngx_conf_t *cf);
+
+static char *
+ngx_http_log_json_loc_req_body_limit(ngx_conf_t *cf,
+        ngx_command_t *cmd, void *conf);
+
+static ngx_command_t ngx_http_log_json_filter_commands[] = {
+    { ngx_string("http_log_json_req_body_limit"),
+        NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+        ngx_http_log_json_loc_req_body_limit,
+        NGX_HTTP_LOC_CONF_OFFSET,
+        0,
+        NULL
+    }
+};
+
+/* config preparation */
+static ngx_http_module_t ngx_http_log_json_filter_module_ctx = {
+    NULL,                                      /* preconfiguration */
+    ngx_http_log_json_filter_init,             /* postconfiguration */
+    ngx_http_log_json_filter_create_main_conf, /* create main configuration */
+    NULL,                                      /* init main configuration */
+    NULL,                                      /* create server configuration */
+    NULL,                                      /* merge server configuration */
+    ngx_http_log_json_filter_create_loc_conf,  /* create location configuration */
+    NULL                                       /* merge location configuration */
+};
+
+ngx_module_t ngx_http_log_json_filter_module = {
+    NGX_MODULE_V1,
+    &ngx_http_log_json_filter_module_ctx,  /* module context */
+    ngx_http_log_json_filter_commands,     /* module directives */
+    NGX_HTTP_MODULE,                       /* module type */
+    NULL,                                  /* init master */
+    NULL,                                  /* init module */
+    NULL,                                  /* init process */
+    NULL,                                  /* init thread */
+    NULL,                                  /* exit thread */
+    NULL,                                  /* exit process */
+    NULL,                                  /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+static char *
+ngx_http_log_json_loc_req_body_limit(ngx_conf_t *cf,
+        ngx_command_t *cmd, void *conf) {
+
+    ngx_http_log_json_filter_loc_conf_t  *lc = conf;
+    ngx_str_t                            *args = cf->args->elts;
+    size_t                               sp = NGX_ERROR;
+
+
+    if (! args) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                "Invalid argument for HTTP request body limit");
+        return NGX_CONF_ERROR;
+    }
+
+    sp = ngx_parse_size(&args[1]);
+    if (sp == (size_t) NGX_ERROR) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                "Invalid argument for HTTP request body limit");
+        return NGX_CONF_ERROR;
+    }
+
+    if (sp == 0) {
+        sp = HTTP_LOG_JSON_REQ_BODY_LIMIT_DEFAULT;
+    }
+
+    lc->req_body_limit = sp;
+
+
+    return NGX_CONF_OK;
+}
+
+
+static size_t
+ngx_http_log_json_get_req_body_limit(ngx_http_request_t *r) {
+    ngx_http_log_json_filter_loc_conf_t        *lc;
+
+    lc = ngx_http_get_module_loc_conf(r, ngx_http_log_json_filter_module);
+
+    if (!lc) {
+        return HTTP_LOG_JSON_REQ_BODY_LIMIT_DEFAULT;
+    }
+    return lc->req_body_limit;
+}
+
+static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
+static ngx_int_t
+ngx_http_log_json_header_filter(ngx_http_request_t *r) {
+
+    ngx_uint_t                          i;
+    ngx_list_part_t                     *part = &r->headers_out.headers.part;
+    ngx_table_elt_t                     *header = part->elts;
+    ngx_table_elt_t                     *header_copy;
+    ngx_array_t                         *headers;
+
+    ngx_str_t                           lcname;
+    ngx_http_variable_value_t           *vv;
+    ngx_uint_t                          varkey;
+    ngx_str_t                   name = ngx_string("http_log_json_resp_headers");
+
+    if (!ngx_http_log_json_needs_header_filter()) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    if (!part->nelts) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    lcname.len = name.len;
+    lcname.data = ngx_pcalloc(r->pool, name.len);
+    varkey = ngx_hash_strlow(lcname.data,
+            name.data, name.len);
+
+    vv = ngx_http_get_variable(r, &lcname, varkey);
+
+    if (!vv) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    headers = ngx_array_create(r->pool, part->nelts, sizeof(ngx_table_elt_t));
+    if (!headers) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    for (i = 0; i < part->nelts ; ++i) {
+
+        header_copy = ngx_array_push(headers);
+        header_copy->hash = -1;
+        header_copy->lowcase_key  = NULL;
+
+        header_copy->key.data = ngx_pcalloc(r->pool, header[i].key.len);
+        if (!header_copy->key.data) {
+            continue;
+        }
+        ngx_memcpy(header_copy->key.data,
+                header[i].key.data, header[i].key.len);
+        header_copy->key.len = header[i].key.len;
+
+        header_copy->value.data = ngx_pcalloc(r->pool, header[i].value.len);
+        if (!header_copy->value.data) {
+            continue;
+        }
+        ngx_memcpy(header_copy->value.data,
+                header[i].value.data, header[i].value.len);
+        header_copy->value.len = header[i].value.len;
+
+    }
+
+    if (headers->nelts < 1) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    ngx_http_log_json_set_variable_resp_headers(r, vv, (uintptr_t) headers);
+
+    return ngx_http_next_header_filter(r);
+}
+
+static ngx_http_request_body_filter_pt  ngx_http_next_request_body_filter;
+
+/* save body filter */
+static ngx_int_t
+ngx_http_log_json_body_filter(ngx_http_request_t *r, ngx_chain_t *in) {
+
+
+    ngx_str_t                  lcname;
+    ngx_http_variable_value_t  *vv;
+    ngx_uint_t                 varkey;
+    ngx_str_t                  name = ngx_string("http_log_json_req_body");
+
+    ngx_chain_t                *cl;
+    size_t                     len = 0;
+    size_t                     count = 0;
+    u_char                     *pos = NULL;
+    ngx_str_t                  payload;
+    size_t                     limit = HTTP_LOG_JSON_REQ_BODY_LIMIT_DEFAULT;
+
+    if (!ngx_http_log_json_needs_body_filter()) {
+        return ngx_http_next_request_body_filter(r, in);
+    }
+    limit = ngx_http_log_json_get_req_body_limit(r);
+    payload.len = 0;
+    /* Finds out the len below limit bytes to save */
+    for (cl = in; cl; cl = cl->next) {
+
+        len = cl->buf->last - cl->buf->pos;
+        if (len < (limit - payload.len)) {
+            payload.len += len;
+        } else {
+            len = (limit - payload.len);
+            payload.len = limit;
+        }
+
+        if (payload.len >= limit) {
+            payload.len = limit;
+            break;
+        }
+    }
+    /* Nothing to save from this iteration */
+    if (!payload.len) {
+        return ngx_http_next_request_body_filter(r, in);
+    }
+
+    //TODO:  support body append from multiple filter calls
+    payload.data = ngx_pcalloc(r->pool, payload.len);
+    if (! payload.data) {
+        //TODO: WARN
+        return ngx_http_next_request_body_filter(r, in);
+    }
+
+    /* Saves body payload */
+    pos = payload.data;
+    count = 0;
+    for (cl = in; cl; cl = cl->next) {
+
+        len = cl->buf->last - cl->buf->pos;
+        if (count + len >= payload.len) {
+            count = payload.len;
+            len = payload.len;
+        } else {
+            count += len;
+        }
+
+        ngx_memcpy(pos, cl->buf->pos, len);
+        pos += len;
+        if (count >= limit) {
+            break;
+        }
+    }
+
+    lcname.len = name.len;
+    lcname.data = ngx_pcalloc(r->pool, name.len);
+    varkey = ngx_hash_strlow(lcname.data, name.data, name.len);
+
+    vv = ngx_http_get_variable(r, &lcname, varkey);
+
+    if (!vv) {
+        return ngx_http_next_header_filter(r);
+    }
+
+    ngx_http_log_json_set_variable_req_body(r, vv, (uintptr_t) &payload);
+    return ngx_http_next_request_body_filter(r, in);
+}
+
+static ngx_int_t
+ngx_http_log_json_filter_init(ngx_conf_t *cf) {
+
+    if (ngx_http_log_json_needs_body_filter()) {
+        ngx_http_next_request_body_filter = ngx_http_top_request_body_filter;
+        ngx_http_top_request_body_filter = ngx_http_log_json_body_filter;
+    }
+
+    if (ngx_http_log_json_needs_header_filter()) {
+        ngx_http_next_header_filter = ngx_http_top_header_filter;
+        ngx_http_top_header_filter = ngx_http_log_json_header_filter;
+    }
+    return NGX_OK;
+}
+
+static void *
+ngx_http_log_json_filter_create_main_conf(ngx_conf_t *cf) {
+
+    ngx_http_log_json_filter_main_conf_t  *conf;
+
+    conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_log_json_filter_main_conf_t));
+    if (conf == NULL) {
+        return NULL;
+    }
+
+    return conf;
+}
+
+static void *
+ngx_http_log_json_filter_create_loc_conf(ngx_conf_t *cf) {
+
+    ngx_http_log_json_filter_loc_conf_t  *conf;
+
+    conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_log_json_filter_loc_conf_t));
+    if (conf == NULL) {
+        return NULL;
+    }
+
+    conf->req_body_limit = HTTP_LOG_JSON_REQ_BODY_LIMIT_DEFAULT;
+
+    return conf;
+}

--- a/src/ngx_http_log_json_kafka.c
+++ b/src/ngx_http_log_json_kafka.c
@@ -1,3 +1,28 @@
+/*
+ * Copyright (C) 2017 Paulo Pacheco
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
 #include <ngx_http_log_json_kafka.h>
 #include <ngx_http_log_json_str.h>
 

--- a/src/ngx_http_log_json_kafka.h
+++ b/src/ngx_http_log_json_kafka.h
@@ -1,3 +1,28 @@
+/*
+ * Copyright (C) 2017 Paulo Pacheco
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
 #ifndef __NGX_KASHA_KAFKA_H__
 #define __NGX_KASHA_KAFKA_H__
 

--- a/src/ngx_http_log_json_module.c
+++ b/src/ngx_http_log_json_module.c
@@ -1,9 +1,32 @@
+/*
+ * Copyright (C) 2017 Paulo Pacheco
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_http.h>
-#include <ngx_http_variables.h>
 #include <ngx_log.h>
-#include <ngx_rbtree.h>
 
 #include <ctype.h>
 #include <assert.h>
@@ -11,8 +34,9 @@
 #include "ngx_http_log_json_str.h"
 #include "ngx_http_log_json_text.h"
 #include "ngx_http_log_json_kafka.h"
+#include "ngx_http_log_json_variables.h"
 
-#define HTTP_LOG_JSON_VER    "0.0.3"
+#define HTTP_LOG_JSON_VER    "0.0.4"
 
 #define HTTP_LOG_JSON_FILE_OUT_LEN (sizeof("file:") - 1)
 #define HTTP_LOG_JSON_LOG_HAS_FILE_PREFIX(str)                                \
@@ -25,6 +49,9 @@
     (ngx_strncmp(str->data,                                                   \
                  http_log_json_kafka_prefix,                                  \
                  HTTP_LOG_JSON_KAFKA_OUT_LEN) ==  0 )
+
+
+#define HTTP_LOG_JSON_REQ_BODY_LIMIT_DEFAULT 512
 
 /* output prefixes */
 static const char *http_log_json_file_prefix              = "file:";
@@ -40,7 +67,19 @@ static const char *http_log_json_int_prefix               = "i:";
 static const char *http_log_json_null_prefix              = "n:";
 
 /*Global variable to indicate the we have kafka locations*/
-static ngx_int_t   http_log_json_has_kafka_locations      = NGX_CONF_UNSET;
+static ngx_int_t   http_log_json_has_kafka_locations          = NGX_CONF_UNSET;
+static ngx_int_t   http_log_json_needs_req_body_filter        = NGX_CONF_UNSET;
+static ngx_int_t   http_log_json_needs_resp_headers_filter    = NGX_CONF_UNSET;
+
+ngx_int_t
+ngx_http_log_json_needs_body_filter() {
+    return http_log_json_needs_req_body_filter != NGX_CONF_UNSET ;
+}
+
+ngx_int_t
+ngx_http_log_json_needs_header_filter() {
+    return http_log_json_needs_resp_headers_filter != NGX_CONF_UNSET ;
+}
 
 typedef enum {
     NGX_HTTP_LOG_JSON_SINK_FILE = 0,
@@ -68,6 +107,7 @@ struct ngx_http_log_json_format_s {
     ngx_array_t                      *items;    /* format items */
     ngx_http_complex_value_t         *filter;    /* filter output */
 };
+typedef struct ngx_http_log_json_format_s     ngx_http_log_json_format_t;
 
 struct ngx_http_log_json_loc_kafka_conf_s {
     rd_kafka_topic_t                 *rkt;       /* kafka topic */
@@ -92,21 +132,17 @@ struct ngx_http_log_json_main_kafka_conf_s {
 typedef struct ngx_http_log_json_main_kafka_conf_s
                                            ngx_http_log_json_main_kafka_conf_t;
 typedef struct ngx_http_log_json_loc_kafka_conf_s
-                                            ngx_http_log_json_loc_kafka_conf_t;
-
+                                           ngx_http_log_json_loc_kafka_conf_t;
 struct ngx_http_log_json_main_conf_s {
-    ngx_http_log_json_main_kafka_conf_t       kafka;
+    ngx_http_log_json_main_kafka_conf_t  kafka;
 };
-
-typedef struct ngx_http_log_json_format_s     ngx_http_log_json_format_t;
 
 struct ngx_http_log_json_output_location_s {
     ngx_str_t                                 location;
     ngx_http_log_json_sink_e                  type;
     ngx_http_log_json_format_t                format;
-    ngx_open_file_t                           * file;
+    ngx_open_file_t                           *file;
     ngx_http_log_json_loc_kafka_conf_t        kafka;
-
 };
 
 typedef struct ngx_http_log_json_output_location_s
@@ -127,14 +163,15 @@ static char *        ngx_http_log_json_loc_format_block(ngx_conf_t *cf,
 static char *
 ngx_http_log_json_loc_output(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 
+
 static void *        ngx_http_log_json_create_main_conf(ngx_conf_t *cf);
 static void *        ngx_http_log_json_create_loc_conf(ngx_conf_t *cf);
 
 static ngx_int_t     ngx_http_log_json_init_worker(ngx_cycle_t *cycle);
 static void          ngx_http_log_json_exit_worker(ngx_cycle_t *cycle);
 
+static ngx_int_t     ngx_http_log_json_pre_config(ngx_conf_t *cf);
 static ngx_int_t     ngx_http_log_json_init(ngx_conf_t *cf);
-
 
 /* http_log_json commands */
 static ngx_command_t ngx_http_log_json_commands[] = {
@@ -222,7 +259,7 @@ static ngx_command_t ngx_http_log_json_commands[] = {
 
 /* http_log_json config preparation */
 static ngx_http_module_t ngx_http_log_json_module_ctx = {
-    NULL,                                  /* preconfiguration */
+    ngx_http_log_json_pre_config,          /* preconfiguration */
     ngx_http_log_json_init,                /* postconfiguration */
     ngx_http_log_json_create_main_conf,    /* create main configuration */
     NULL,                                  /* init main configuration */
@@ -251,12 +288,13 @@ ngx_module_t ngx_http_log_json_module = {
 /* Initialized stuff per http_log_json worker.*/
 static ngx_int_t ngx_http_log_json_init_worker(ngx_cycle_t *cycle) {
 
+    ngx_http_log_json_main_conf_t  *conf =
+        ngx_http_cycle_get_module_main_conf(cycle, ngx_http_log_json_module);
+
+    /* From this point we just are init kafka stuff */
     if (http_log_json_has_kafka_locations == NGX_CONF_UNSET ) {
         return NGX_OK;
     }
-
-    ngx_http_log_json_main_conf_t  *conf =
-        ngx_http_cycle_get_module_main_conf(cycle, ngx_http_log_json_module);
 
     /* kafka */
     /* - default values - */
@@ -349,7 +387,6 @@ static ngx_int_t ngx_http_log_json_init_worker(ngx_cycle_t *cycle) {
             conf_debug_key,
             &conf_all_value);
 #endif
-
     /* create kafka handler */
     conf->kafka.rk = http_log_json_kafka_producer_new(
             cycle->pool,
@@ -378,37 +415,44 @@ static ngx_int_t ngx_http_log_json_init_worker(ngx_cycle_t *cycle) {
     return NGX_OK;
 }
 
+
 /* Things that a http_log_json maker must do before go home. */
 void
 ngx_http_log_json_exit_worker(ngx_cycle_t *cycle) {
     //TODO: cleanup kafka stuff
 }
 
-static ngx_int_t ngx_http_log_json_write_sink_file(ngx_fd_t fd,
-        const char *txt) {
+static ngx_int_t
+ngx_http_log_json_write_sink_file(ngx_log_t *log,
+        ngx_fd_t fd, const char *txt, size_t len) {
 
-    size_t to_write = strlen(txt);
-    size_t written = ngx_write_fd(fd, (u_char *)txt, strlen(txt));
-    if (to_write != written) {
+    size_t written = ngx_write_fd(fd, (u_char *)txt, len);
+    if (len != written) {
+        ngx_log_error(NGX_LOG_EMERG, log, 0, "Mismatch size");
         return NGX_ERROR;
     }
-    ngx_write_fd(fd, "\n", 1);
     return NGX_OK;
 }
 
-/* handler - format and print */
+
+/* log handler - format and print */
 static ngx_int_t ngx_http_log_json_log_handler(ngx_http_request_t *r) {
 
-    ngx_http_log_json_loc_conf_t   *lc;
-    ngx_http_log_json_main_conf_t  *mcf;
-    ngx_str_t                      filter_val;
-    char                           *txt;
-    size_t                         i;
-    int                            err;
+    ngx_http_log_json_loc_conf_t        *lc;
+    ngx_http_log_json_main_conf_t       *mcf;
+    ngx_str_t                           filter_val;
+    char                                *txt;
+    size_t                              i, len;
+    int                                 err;
     ngx_http_log_json_output_location_t *arr;
     ngx_http_log_json_output_location_t *location;
 
     lc = ngx_http_get_module_loc_conf(r, ngx_http_log_json_module);
+
+    /*FIXME: Try to discard local upstream requests */
+    if (!r->upstream && r->lingering_time) {
+        return NGX_OK;
+    }
 
     /* Location to eat http_log_json was not found */
     if (!lc) {
@@ -425,6 +469,8 @@ static ngx_int_t ngx_http_log_json_log_handler(ngx_http_request_t *r) {
         ngx_strncasecmp((u_char *)"CONNECT", r->request_line.data, 7) == 0) {
         return NGX_OK;
     }
+
+    mcf = ngx_http_get_module_main_conf(r, ngx_http_log_json_module);
 
     arr = lc->locations->elts;
     for (i = 0; i < lc->locations->nelts; ++i) {
@@ -459,20 +505,26 @@ static ngx_int_t ngx_http_log_json_log_handler(ngx_http_request_t *r) {
 
         /* Write to file */
         if (location->type == NGX_HTTP_LOG_JSON_SINK_FILE) {
-            if( location->file != NULL) {
-                if (ngx_http_log_json_write_sink_file(
-                            location->file->fd, txt) == NGX_ERROR) {
-                    /* WARN ? */
-                    ;
-                }
+
+            if (!location->file) {
+                continue;
+            }
+
+            len = strlen(txt);
+            if (!len) {
+                ngx_log_error(NGX_LOG_EMERG, r->pool->log, 0, "Empty line");
+                continue;
+            }
+
+            if (ngx_http_log_json_write_sink_file(r->pool->log,
+                        location->file->fd, txt, len) == NGX_ERROR) {
+                ngx_log_error(NGX_LOG_EMERG, r->pool->log, 0, "Write Error!");
             }
             continue;
         }
 
         /* Write to kafka */
         if (location->type == NGX_HTTP_LOG_JSON_SINK_KAFKA) {
-
-            mcf = ngx_http_get_module_main_conf(r, ngx_http_log_json_module);
 
             /* don't do anything if no kafka brokers to send */
             if (! mcf->kafka.valid_brokers) {
@@ -536,6 +588,13 @@ static ngx_int_t ngx_http_log_json_log_handler(ngx_http_request_t *r) {
 }
 
 static ngx_int_t
+ngx_http_log_json_pre_config(ngx_conf_t *cf) {
+
+    ngx_http_log_json_register_variables(cf);
+    return NGX_OK;
+}
+
+static ngx_int_t
 ngx_http_log_json_init(ngx_conf_t *cf) {
 
     ngx_http_handler_pt        *h;
@@ -551,6 +610,7 @@ ngx_http_log_json_init(ngx_conf_t *cf) {
         return NGX_ERROR;
     }
     *h = ngx_http_log_json_log_handler;
+
     return NGX_OK;
 }
 
@@ -618,8 +678,8 @@ ngx_http_log_json_read_format(ngx_conf_t *cf,
             return NGX_ERROR;
         }
 
-        key_str   = ngx_palloc(cf->pool, sizeof(ngx_str_t));
-        value_str = ngx_palloc(cf->pool, sizeof(ngx_str_t));
+        key_str   = ngx_pcalloc(cf->pool, sizeof(ngx_str_t));
+        value_str = ngx_pcalloc(cf->pool, sizeof(ngx_str_t));
 
         for (i=0; i < matched; i++) {
             ret = pcre_copy_substring((const char *)spec.data,
@@ -630,19 +690,19 @@ ngx_http_log_json_read_format(ngx_conf_t *cf,
             }
             /* i = 1 => key - item name */
             if (i == 1) {
-                key_str->data = ngx_palloc(cf->pool, ret);
+                key_str->data = ngx_pcalloc(cf->pool, ret);
                 key_str->len = ret;
                 ngx_cpystrn(key_str->data, (u_char *)value, ret+1);
             }
             /* i = 2 => value */
             if (i == 2) {
-                value_str->data = ngx_palloc(cf->pool, ret);
+                value_str->data = ngx_pcalloc(cf->pool, ret);
                 value_str->len = ret;
                 ngx_cpystrn(value_str->data, (u_char *)value, ret+1);
             }
         }
 
-        cv = ngx_palloc(cf->pool, sizeof(ngx_http_complex_value_t));
+        cv = ngx_pcalloc(cf->pool, sizeof(ngx_http_complex_value_t));
         if (cv == NULL) {
             ngx_log_error(NGX_LOG_ERR, cf->pool->log,
                     0, "Failed to configure http_log_json_format.");
@@ -666,11 +726,38 @@ ngx_http_log_json_read_format(ngx_conf_t *cf,
         }
 
         item->name = key_str;
+
+        /* Saves var name */
+        if (*value_str->data == '$') {
+            item->var_name.data= ngx_pcalloc(cf->pool, value_str->len - 1);
+            ngx_memcpy(item->var_name.data,
+                    value_str->data + 1, value_str->len - 1);
+            item->var_name.len = value_str->len - 1;
+
+            /* enables body filter if needed */
+            if (http_log_json_needs_req_body_filter == NGX_CONF_UNSET
+                    && ngx_http_log_json_is_local_variable(
+                        &item->var_name)
+                    && ngx_http_log_json_local_variable_needs_body_filter(
+                        &item->var_name)) {
+                http_log_json_needs_req_body_filter = 1;
+            }
+
+            /* enables header filter if needed */
+            if (http_log_json_needs_resp_headers_filter== NGX_CONF_UNSET
+                    && ngx_http_log_json_is_local_variable(
+                        &item->var_name)
+                    && ngx_http_log_json_local_variable_needs_header_filter(
+                        &item->var_name)) {
+                http_log_json_needs_resp_headers_filter = 1;
+            }
+        }
+
         item->is_array = 0;
 
         /* Check and save type from name prefix */
         /* Default is JSON_STRING type */
-        item->type = TYPE_JSON_STRING;
+        item->type = ngx_http_log_json_type_string();
         if (ngx_strncmp(item->name->data,
                     http_log_json_array_prefix, 2) == 0) {
             item->is_array = 1;
@@ -678,37 +765,37 @@ ngx_http_log_json_read_format(ngx_conf_t *cf,
         }
 
         if (ngx_strncmp(item->name->data + array_prefix_len,
-                    http_log_json_null_prefix, 2) == 0) {
-            item->type = TYPE_JSON_NULL;
-            item->name->data += 2 + array_prefix_len;
-            item->name->len  -= 2 + array_prefix_len;
-        } else if (ngx_strncmp(item->name->data + array_prefix_len,
                     http_log_json_int_prefix, 2) == 0) {
-            item->type = TYPE_JSON_INTEGER;
+            item->type = ngx_http_log_json_type_integer();
             item->name->data += 2 + array_prefix_len;
             item->name->len  -= 2 + array_prefix_len;
         } else if (ngx_strncmp(item->name->data + array_prefix_len,
                     http_log_json_real_prefix, 2) == 0) {
-            item->type = TYPE_JSON_REAL;
+            item->type = ngx_http_log_json_type_real();
             item->name->data += 2 + array_prefix_len;
             item->name->len  -= 2 + array_prefix_len;
         } else if (ngx_strncmp(item->name->data + array_prefix_len,
                     http_log_json_string_prefix, 2) == 0) {
-            item->type = TYPE_JSON_STRING;
+            item->type = ngx_http_log_json_type_string();
+            item->name->data += 2 + array_prefix_len;
+            item->name->len  -= 2 + array_prefix_len;
+        } else if (ngx_strncmp(item->name->data + array_prefix_len,
+                    http_log_json_null_prefix, 2) == 0) {
+            item->type = ngx_http_log_json_type_null();
             item->name->data += 2 + array_prefix_len;
             item->name->len  -= 2 + array_prefix_len;
         } else if (ngx_strncmp(item->name->data + array_prefix_len,
                     http_log_json_boolean_prefix, 2) == 0) {
             if (ngx_strncmp(value_str->data + array_prefix_len,
                         http_log_json_true_value, 4) == 0) {
-                item->type = TYPE_JSON_TRUE;
+                item->type = ngx_http_log_json_type_true();
             } else {
-                item->type = TYPE_JSON_FALSE;
+                item->type = ngx_http_log_json_type_false();
             }
             item->name->data += 2 + array_prefix_len;
             item->name->len  -= 2 + array_prefix_len;
         } else {
-            item->type = TYPE_JSON_STRING;
+            item->type = ngx_http_log_json_type_string();
             if (item->is_array) {
                 item->name->data += array_prefix_len;
                 item->name->len  -= array_prefix_len;
@@ -788,6 +875,7 @@ ngx_http_log_json_loc_format_block(ngx_conf_t *cf, ngx_command_t *cmd, void *con
     ngx_http_log_json_format_t           *new_format;
     ngx_http_log_json_loc_conf_t         *lc = conf;
     ngx_http_compile_complex_value_t     ccv;
+    ngx_str_t                            s;
 
     args = cf->args->elts;
     /* this should never happen, but we check it anyway */
@@ -816,19 +904,16 @@ ngx_http_log_json_loc_format_block(ngx_conf_t *cf, ngx_command_t *cmd, void *con
             sizeof(ngx_http_log_json_item_t)
             );
 
-   if (ngx_http_log_json_read_format(cf, new_format) != NGX_OK) {
-       ngx_conf_log_error(NGX_LOG_EMERG, cf,
-               0, "invalid format read");
-       return NGX_CONF_ERROR;
-   }
-
+    if (ngx_http_log_json_read_format(cf, new_format) != NGX_OK) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf,
+                0, "invalid format read");
+        return NGX_CONF_ERROR;
+    }
 
     /*check and save the if filter condition */
     if (cf->args->nelts >= 4 && args[3].data != NULL) {
 
         if (ngx_strncmp(args[3].data, "if=", 3) == 0) {
-
-            ngx_str_t s;
             s.len = args[3].len - 3;
             s.data = args[3].data + 3;
 
@@ -836,7 +921,7 @@ ngx_http_log_json_loc_format_block(ngx_conf_t *cf, ngx_command_t *cmd, void *con
 
             ccv.cf = cf;
             ccv.value = &s;
-            ccv.complex_value = ngx_palloc(cf->pool,
+            ccv.complex_value = ngx_pcalloc(cf->pool,
                     sizeof(ngx_http_complex_value_t));
             if (ccv.complex_value == NULL) {
                 return NGX_CONF_ERROR;
@@ -851,7 +936,7 @@ ngx_http_log_json_loc_format_block(ngx_conf_t *cf, ngx_command_t *cmd, void *con
     return NGX_CONF_OK;
 }
 
-/* Register a output location destination for the HTTP location config 
+/* Register a output location destination for the HTTP location config
  * `http_log_json_output`
  *
  * Supported output destinations:
@@ -889,7 +974,7 @@ ngx_http_log_json_loc_output(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) {
             break;
         }
     }
-    
+
     /* Do not accept unknown format names */
     if (!found)  {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
@@ -915,7 +1000,7 @@ ngx_http_log_json_loc_output(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) {
                 "Invalid prefix [%v] for HTTP log JSON output location", value);
         return NGX_CONF_ERROR;
     }
-    
+
     if (!new_location) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
                 "Failed to add [%v] for HTTP log JSON output location", value);

--- a/src/ngx_http_log_json_module.h
+++ b/src/ngx_http_log_json_module.h
@@ -23,28 +23,14 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-#ifndef __NGX_KASHA_STR_H__
-#define __NGX_KASHA_STR_H__
-
-#include <ngx_core.h>
-
-const char *
-ngx_http_log_json_buf_dup_len(ngx_pool_t *pool, u_char *src, size_t len);
-
-u_char *
-ngx_http_log_json_str_dup(ngx_pool_t *pool, ngx_str_t *src);
-
-ngx_str_t *
-ngx_http_log_json_str_dup_from_buf_len(ngx_pool_t *pool,
-        ngx_str_t *src, size_t len);
-
-u_char *
-ngx_http_log_json_str_dup_len(ngx_pool_t *pool, ngx_str_t *src, size_t len);
+#ifndef __NGX_HTTP_LOG_JSON_MODULE_H__
+#define __NGX_HTTP_LOG_JSON_MODULE_H__
 
 ngx_int_t
-ngx_http_log_json_str_clone(ngx_pool_t *pool, ngx_str_t *src, ngx_str_t *dst);
+ngx_http_log_json_needs_body_filter();
 
-ngx_uint_t
-ngx_http_log_json_str_split_count(ngx_str_t *value, u_char separator);
+ngx_int_t
+ngx_http_log_json_needs_header_filter();
 
-#endif //__NGX_KASHA_STR_H__
+#endif // __NGX_HTTP_LOG_JSON_MODULE_H__
+

--- a/src/ngx_http_log_json_str.c
+++ b/src/ngx_http_log_json_str.c
@@ -1,3 +1,28 @@
+/*
+ * Copyright (C) 2017 Paulo Pacheco
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
 #include <ngx_http_log_json_str.h>
 
 /* duplicates and set as null terminated */
@@ -12,6 +37,40 @@ ngx_http_log_json_str_dup(ngx_pool_t *pool, ngx_str_t *src) {
     }
 
     ngx_memcpy(dst, src->data, src->len);
+    return dst;
+}
+
+ngx_str_t *
+ngx_http_log_json_str_dup_from_buf_len(ngx_pool_t *pool,
+        ngx_str_t *src, size_t len) {
+
+    ngx_str_t *str = ngx_pcalloc(pool, sizeof(ngx_str_t));
+    if (str == NULL) {
+        return NULL;
+    }
+
+    str->data = ngx_pcalloc(pool, len);
+    if (str->data == NULL) {
+        return NULL;
+    }
+
+    ngx_memcpy(str->data, src, len);
+    str->len = len;
+
+    return str;
+}
+
+const char *
+ngx_http_log_json_buf_dup_len(ngx_pool_t *pool, u_char *src, size_t len) {
+
+    char *dst;
+
+    dst = ngx_pcalloc(pool, len + 1);
+    if (dst == NULL) {
+        return NULL;
+    }
+
+    ngx_memcpy(dst, src, len);
     return dst;
 }
 

--- a/src/ngx_http_log_json_text.h
+++ b/src/ngx_http_log_json_text.h
@@ -1,25 +1,54 @@
+/*
+ * Copyright (C) 2017 Paulo Pacheco
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
 #ifndef __NGX_HTTP_LOG_JSON_TEXT_H__
 #define __NGX_HTTP_LOG_JSON_TEXT_H__
-
-static const char * TYPE_JSON_STRING     = "JSON_STRING";
-static const char * TYPE_JSON_INTEGER    = "JSON_INTEGER";
-static const char * TYPE_JSON_REAL       = "JSON_REAL";
-static const char * TYPE_JSON_TRUE       = "JSON_TRUE";
-static const char * TYPE_JSON_FALSE      = "JSON_FALSE";
-static const char * TYPE_JSON_NULL       = "JSON_NULL";
 
 struct ngx_http_log_json_item_s {
     const char                           *type;
     ngx_str_t                            *name;
+    ngx_str_t                            var_name;
     ngx_int_t                            is_array;
     ngx_http_compile_complex_value_t     *ccv;
 };
 
 typedef struct ngx_http_log_json_item_s  ngx_http_log_json_item_t;
 
+const char * ngx_http_log_json_type_string();
+const char * ngx_http_log_json_type_integer();
+const char * ngx_http_log_json_type_real();
+const char * ngx_http_log_json_type_true();
+const char * ngx_http_log_json_type_false();
+const char * ngx_http_log_json_type_null();
+
 /* Global alloc funcs registration */
 void
 ngx_http_log_json_set_alloc_funcs();
+
+void
+set_current_mem_pool(ngx_pool_t *pool);
 
 /* Dumps to text format the JSON for the items for this request. */
 char *

--- a/src/ngx_http_log_json_variables.c
+++ b/src/ngx_http_log_json_variables.c
@@ -1,0 +1,255 @@
+/*
+ * Copyright (C) 2017 Paulo Pacheco
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include <ngx_regex.h>
+#include <ngx_http.h>
+#include <ngx_http.h>
+#include <ngx_queue.h>
+#include <ngx_http_variables.h>
+
+#include "ngx_http_log_json_variables.h"
+#include "ngx_http_log_json_text.h"
+
+#include <jansson.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+typedef ngx_queue_t *(*get_body_queue_pt)(ngx_http_request_t *r);
+
+static ngx_int_t
+ngx_http_log_json_get_variable_req_headers(ngx_http_request_t *r,
+        ngx_http_variable_value_t *v, uintptr_t data);
+
+
+
+/* variables list */
+static ngx_http_variable_t  ngx_http_log_json_variables_list[] = {
+        {   ngx_string("http_log_json_req_headers"),
+            NULL,
+            ngx_http_log_json_get_variable_req_headers,
+            0, 0, 0
+        },
+        {   ngx_string("http_log_json_resp_headers"),
+            ngx_http_log_json_set_variable_resp_headers,
+            NULL,
+            0, 0, 0
+        },
+        {   ngx_string("http_log_json_req_body"),
+            ngx_http_log_json_set_variable_req_body,
+            NULL,
+            0, 0, 0
+        }
+};
+
+
+
+ngx_http_variable_t *
+ngx_http_log_json_variables(size_t *len) {
+
+    *len =
+      sizeof(ngx_http_log_json_variables_list)
+      / sizeof(ngx_http_variable_t);
+
+    return ngx_http_log_json_variables_list;
+}
+
+ngx_int_t
+ngx_http_log_json_is_local_variable(ngx_str_t *name) {
+
+    size_t len = 0, i = 0;
+    ngx_http_variable_t * vars;
+
+    if (!name || !name->data || !name->len) {
+        return 0;
+    }
+
+    vars = ngx_http_log_json_variables(&len);
+    for (i = 0; i < len; i++) {
+        if (ngx_strncmp(vars[i].name.data, name->data, vars[i].name.len) == 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+ngx_int_t
+ngx_http_log_json_local_variable_needs_body_filter(ngx_str_t *name) {
+    if (!name || !name->data || !name->len) {
+        return 0;
+    }
+
+    if (ngx_strncmp("http_log_json_req_body", name->data,
+                sizeof("http_log_json_req_body")) == 0) {
+        return 1;
+    }
+    return NGX_ERROR;
+}
+
+ngx_int_t
+ngx_http_log_json_local_variable_needs_header_filter(ngx_str_t *name) {
+
+    if (!name || !name->data || !name->len) {
+        return 0;
+    }
+
+    if (ngx_strncmp("http_log_json_resp_headers", name->data,
+                sizeof("http_log_json_resp_headers")) == 0) {
+        return 1;
+    }
+    return 0;
+}
+
+void
+ngx_http_log_json_register_variables(ngx_conf_t *cf) {
+
+    ngx_http_variable_t         *v;
+    size_t                      l = 0, local_vars_len;
+    ngx_http_variable_t         *local_vars = NULL;
+
+    local_vars = ngx_http_log_json_variables(&local_vars_len);
+    /* Register variables */
+    for (l = 0; l < local_vars_len ; ++l) {
+        v = ngx_http_add_variable(cf,
+                &local_vars[l].name, local_vars[l].flags);
+        if (v == NULL) {
+            continue;
+        }
+        *v = local_vars[l];
+    }
+}
+
+static ngx_int_t
+ngx_http_log_json_get_variable_req_headers(ngx_http_request_t *r,
+            ngx_http_variable_value_t *v, uintptr_t data) {
+
+    ngx_uint_t                              i;
+    ngx_list_part_t                         *part = &r->headers_in.headers.part;
+    ngx_table_elt_t                         *header = part->elts;
+    char                                    *key = NULL;
+    json_t                                  *object = json_object();
+
+    for (i = 0; i < part->nelts ; ++i) {
+        if (!header[i].key.data  || !header[i].key.len) {
+            continue;
+        }
+        key = ngx_pcalloc(r->pool, header[i].key.len + 1);
+        if (!key) {
+            return NGX_ERROR;
+        }
+        ngx_memcpy(key, header[i].key.data, header[i].key.len);
+        json_object_set(object, (const char *) key,
+                json_stringn((const char *) header[i].value.data,
+                    header[i].value.len));
+    }
+    v->data = (void *) object;
+
+    return NGX_OK;
+}
+
+void
+ngx_http_log_json_set_variable_resp_headers(ngx_http_request_t *r,
+            ngx_http_variable_value_t *v, uintptr_t data) {
+
+    size_t                       i;
+    ngx_table_elt_t              *header;
+    ngx_array_t                  *headers = (ngx_array_t *) data;
+    json_t                       *object;
+    char                         *key;
+
+    if (!headers) {
+        return;
+    }
+
+    /* FIXME Maybe called with strange values */
+    if (headers->nelts > 256) {
+        return;
+    }
+
+    set_current_mem_pool(r->pool);
+    object = json_object();
+    if (!object) {
+        return;
+    }
+
+    header = headers->elts;
+    for (i = 0; i < headers->nelts; ++i) {
+
+        if (!header[i].key.data  || !header[i].key.len) {
+            continue;
+        }
+        key = ngx_pcalloc(r->pool, header[i].key.len + 1);
+        if (!key) {
+            return;
+        }
+        ngx_memcpy(key, header[i].key.data, header[i].key.len);
+        json_object_set(object, (const char *) key,
+                json_stringn((const char *) header[i].value.data,
+                    header[i].value.len));
+    }
+
+    if (object) {
+        v->valid = 1;
+        v->data = (void *) object;
+    }
+    set_current_mem_pool(NULL);
+}
+
+
+void
+ngx_http_log_json_set_variable_req_body(ngx_http_request_t *r,
+        ngx_http_variable_value_t *v, uintptr_t data) {
+
+    ngx_str_t                          base64;
+    ngx_str_t                         *payload;
+    json_t                            *object = NULL;
+    payload = (ngx_str_t *) data;
+
+    if (!payload || !payload->data) {
+        return;
+    }
+
+    base64.len = ngx_base64_encoded_length(payload->len);
+    base64.data = ngx_pcalloc(r->pool, base64.len);
+    if (!base64.data) {
+        return;
+    }
+
+    ngx_encode_base64(&base64, payload);
+
+    set_current_mem_pool(r->pool);
+    object = json_stringn((const char *) base64.data, base64.len);
+    if (object) {
+        v->valid = 1;
+        v->data = (void *) object;
+    }
+    set_current_mem_pool(NULL);
+
+}

--- a/src/ngx_http_log_json_variables.h
+++ b/src/ngx_http_log_json_variables.h
@@ -23,28 +23,32 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-#ifndef __NGX_KASHA_STR_H__
-#define __NGX_KASHA_STR_H__
+#ifndef __NGX_HTTP_LOG_JSON_VARIABLES_H__
+#define __NGX_HTTP_LOG_JSON_VARIABLES_H__
 
-#include <ngx_core.h>
+#include <ngx_config.h>
+#include <ngx_http_variables.h>
 
-const char *
-ngx_http_log_json_buf_dup_len(ngx_pool_t *pool, u_char *src, size_t len);
+void
+ngx_http_log_json_register_variables(ngx_conf_t *cf);
 
-u_char *
-ngx_http_log_json_str_dup(ngx_pool_t *pool, ngx_str_t *src);
+void
+ngx_http_log_json_set_variable_resp_headers(ngx_http_request_t *r,
+            ngx_http_variable_value_t *v, uintptr_t data);
 
-ngx_str_t *
-ngx_http_log_json_str_dup_from_buf_len(ngx_pool_t *pool,
-        ngx_str_t *src, size_t len);
-
-u_char *
-ngx_http_log_json_str_dup_len(ngx_pool_t *pool, ngx_str_t *src, size_t len);
+void
+ngx_http_log_json_set_variable_req_body(ngx_http_request_t *r,
+            ngx_http_variable_value_t *v, uintptr_t data);
 
 ngx_int_t
-ngx_http_log_json_str_clone(ngx_pool_t *pool, ngx_str_t *src, ngx_str_t *dst);
+ngx_http_log_json_is_local_variable(ngx_str_t *name);
 
-ngx_uint_t
-ngx_http_log_json_str_split_count(ngx_str_t *value, u_char separator);
+ngx_int_t
+ngx_http_log_json_local_variable_needs_body_filter(ngx_str_t *name);
 
-#endif //__NGX_KASHA_STR_H__
+ngx_int_t
+ngx_http_log_json_local_variable_needs_header_filter(ngx_str_t *name);
+
+
+#endif // __NGX_HTTP_LOG_JSON_VARIABLES_H__
+


### PR DESCRIPTION
module: variable $http_log_json_req_headers;

Creates a json object with all request headers.

Example:

```
"req": {
    "headers": {
        "Host": "localhost",
        "User-Agent": "curl/7.52.1",
        "Accept": "*/*"
    }
}
```

----

module: variable $http_log_json_req_body;

Log request body encoded as base64.
It requires proxy_pass configuration at logging location.

Example:

```
"req": {
    "body": "Zm9v"
}
```
----

module: location directive http_log_json_req_body_limit 512;

Default limit is 512 bytes.

Argument is a size string. May be 1k or 1M, but avoid this!

----

module: variable $http_log_json_resp_headers;

    Creates a json object with available response headers.

    Example:

    ```
    resp": {
    "headers": {
      "Last-Modified": "Sat, 01 Apr 2017 13:34:28 GMT",
      "ETag": "\"58dfac64-12\"",
      "X-Foo": "bar",
      "Accept-Ranges": "bytes"
    }
    ```

----