### PR TITLE
ngx-json-log: log bad requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ For HTTP logging, if kafka output is used the value from $request_id nginx varia
 
 The $request_id is only available for nginx (>=1.11.0).
 
+
+#### Log HTTP Bad Requests
+
+Nginx will short circuit response if the client sends a Bad Request. In that case, the log handler will not be run.
+
+In order to, capture and log these requests we can define at server level, a format and output location for this requests.
+
+The directives json_err_log_* (same suffixes as the directives for location logging), should be used for this case.
+
+Additionally, the variable $http_json_err_log_req will be set with a base64 encodede string for the data sent from the client, until the limit set by **http_json_log_req_body_limit** is reached.
+
 #### Example Configuration
 
 
@@ -218,13 +229,20 @@ To ease reading, it's shown here formatted with newlines.
  ```
 
 
+
 ### Directives
 
----
+
 * Syntax: **json_log_format** _format_name_ { _format_ } _if_=...;
 * Default: —
 * Context: http location
 * Context: stream server
+
+---
+
+* Syntax: **json_err_log_format** _format_name_ { _format_ } _if_=...;
+* Default: —
+* Context: http server
 
 ###### _format_name_ ######
 
@@ -240,10 +258,16 @@ Works the same way as _if_ argument from http [access_log](http://nginx.org/en/d
 
 ---
 
-* Syntax: **json_log** _location_ _format_name_ 
+* Syntax: **json_log** _location_ _format_name_
 * Default: —
 * Context: http location
 * Context: stream server
+
+----
+
+* Syntax: **json_err_log** _location_ _format_name_
+* Default: —
+* Context: http server
 
 ###### _location_ ######
 
@@ -268,12 +292,24 @@ The format to use when writing to output destination.
 * Context: http main
 * Context: stream main
 
+----
+
+* Syntax: **json_err_log_kafka_brokers** list of brokers separated by spaces;
+* Default: —
+* Context: http main
+
 ---
 
 * Syntax: **json_log_kafka_client_id** _id_;
 * Default: nginx
 * Context: http main
 * Context: stream main
+
+----
+
+* Syntax: **json_err_log_kafka_client_id** _id_;
+* Default: nginx
+* Context: http server
 
 ---
 
@@ -282,12 +318,24 @@ The format to use when writing to output destination.
 * Context: http main
 * Context: stream main
 
+----
+
+* Syntax: **json_err_log_kafka_compression** _compression_codec_;
+* Default: snappy
+* Context: http server
+
 ---
 
 * Syntax: **json_log_kafka_log_level** _numeric_log_level_;
 * Default: 6
 * Context: http main
 * Context: stream main
+
+----
+
+* Syntax: **json_err_log_kafka_log_level** _numeric_log_level_;
+* Default: 6
+* Context: http server
 
 ---
 
@@ -296,12 +344,24 @@ The format to use when writing to output destination.
 * Context: http main
 * Context: stream main
 
+----
+
+* Syntax: **json_err_log_kafka_max_retries** _numeric_;
+* Default: 0
+* Context: http main
+
 ---
 
 * Syntax: **json_log_kafka_buffer_max_messages** _numeric_;
 * Default: 100000
 * Context: http main
 * Context: stream main
+
+----
+
+* Syntax: **json_err_log_kafka_buffer_max_messages** _numeric_;
+* Default: 100000
+* Context: http main
 
 ---
 
@@ -310,12 +370,24 @@ The format to use when writing to output destination.
 * Context: http main
 * Context: stream main
 
+----
+
+* Syntax: **json_err_log_kafka_backoff_ms** _numeric_;
+* Default: 10
+* Context: http main
+
 ---
 
 * Syntax: **json_log_kafka_partition** _partition_;
 * Default: RD_KAFKA_PARTITION_UA
 * Context: http main
 * Context: stream main
+
+----
+
+* Syntax: **json_err_log_kafka_partition** _partition_;
+* Default: RD_KAFKA_PARTITION_UA
+* Context: http main
 
 ---
 
@@ -587,6 +659,6 @@ nginx-json-zookeeper   /bin/sh -c /usr/sbin/sshd  ...   Up      0.0.0.0:2181->21
 
 ```
 
-An additional docker service for development only it's available.
+An additional docker service for development it's available.
 
 Just uncomment the nginx-json-dev service block.

--- a/src/ngx_http_json_log_filter_module.c
+++ b/src/ngx_http_json_log_filter_module.c
@@ -30,8 +30,21 @@
 
 #include "ngx_http_json_log_module.h"
 #include "ngx_http_json_log_variables.h"
+#include "ngx_json_log_text.h"
+#include "ngx_json_log_kafka.h"
+#include "ngx_json_log_output.h"
 
 #define HTTP_LOG_JSON_REQ_BODY_LIMIT_DEFAULT 512
+
+/* data structures */
+
+
+typedef struct ngx_http_json_log_main_conf_s     ngx_http_json_log_main_conf_t;
+
+/* configuration kafka constants */
+static ngx_int_t   http_json_log_filter_has_kafka_locations     = NGX_CONF_UNSET;
+static const char *conf_req_required_acks_key  = "request.required.acks";
+static ngx_str_t   conf_zero_value             = ngx_string("0");
 
 struct ngx_http_json_log_req_body_s {
     ngx_http_request_t                       *r;
@@ -43,17 +56,18 @@ typedef struct ngx_http_json_log_req_body_s ngx_http_json_log_req_body_t;
 typedef struct ngx_http_json_log_resp_headers_s
     ngx_http_json_log_resp_headers_t;
 
-/* main config state */
+/* main config */
 struct ngx_http_json_log_filter_main_conf_s {
+    ngx_json_log_main_kafka_conf_t  kafka;
 };
+typedef struct ngx_http_json_log_filter_main_conf_s
+    ngx_http_json_log_filter_main_conf_t;
 
 /* location config */
 struct ngx_http_json_log_filter_loc_conf_s {
     size_t                req_body_limit;
 };
 
-typedef struct ngx_http_json_log_filter_main_conf_s
-    ngx_http_json_log_filter_main_conf_t;
 
 typedef struct ngx_http_json_log_filter_loc_conf_s
     ngx_http_json_log_filter_loc_conf_t;
@@ -62,14 +76,26 @@ static void *
 ngx_http_json_log_filter_create_main_conf(ngx_conf_t *cf);
 
 static void *
+ngx_http_json_log_filter_create_srv_conf(ngx_conf_t *cf);
+
+static void *
 ngx_http_json_log_filter_create_loc_conf(ngx_conf_t *cf);
+
 
 static ngx_int_t
 ngx_http_json_log_filter_init(ngx_conf_t *cf);
 
+static ngx_int_t
+ngx_http_json_log_filter_init_worker(ngx_cycle_t *cycle);
+
+
+/* Configuration callbacks */
 static char *
 ngx_http_json_log_loc_req_body_limit(ngx_conf_t *cf,
         ngx_command_t *cmd, void *conf);
+
+static char *
+ngx_http_json_log_srv_output(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 
 static ngx_command_t ngx_http_json_log_filter_commands[] = {
     { ngx_string("http_json_log_req_body_limit"),
@@ -78,7 +104,88 @@ static ngx_command_t ngx_http_json_log_filter_commands[] = {
         NGX_HTTP_LOC_CONF_OFFSET,
         0,
         NULL
-    }
+    },
+    { ngx_string("json_err_log_format"),
+        NGX_HTTP_SRV_CONF|NGX_CONF_TAKE2|NGX_CONF_TAKE3,
+        ngx_http_json_log_srv_format_block,
+        NGX_HTTP_SRV_CONF_OFFSET,
+        0,
+        NULL
+    },
+    /* OUTPUT LOCATION */
+    { ngx_string("json_err_log"),
+        NGX_HTTP_SRV_CONF|NGX_CONF_TAKE2,
+        ngx_http_json_log_srv_output,
+        NGX_HTTP_SRV_CONF_OFFSET,
+        0,
+        NULL
+    },
+    /* KAFKA */
+    {
+        ngx_string("json_err_log_kafka_client_id"),
+        NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_str_slot,
+        NGX_HTTP_MAIN_CONF_OFFSET,
+        offsetof(ngx_http_json_log_filter_main_conf_t, kafka.client_id),
+        NULL
+    },
+    {
+        ngx_string("json_err_log_kafka_brokers"),
+        NGX_HTTP_MAIN_CONF|NGX_CONF_1MORE,
+        ngx_conf_set_str_array_slot,
+        NGX_HTTP_MAIN_CONF_OFFSET,
+        offsetof(ngx_http_json_log_filter_main_conf_t, kafka.brokers),
+        NULL
+    },
+    {
+        ngx_string("json_err_log_kafka_compression"),
+        NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_str_slot,
+        NGX_HTTP_MAIN_CONF_OFFSET,
+        offsetof(ngx_http_json_log_filter_main_conf_t, kafka.compression),
+        NULL
+    },
+    {
+        ngx_string("json_err_log_kafka_partition"),
+        NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_num_slot,
+        NGX_HTTP_MAIN_CONF_OFFSET,
+        offsetof(ngx_http_json_log_filter_main_conf_t, kafka.partition),
+        NULL
+    },
+    {
+        ngx_string("json_err_log_kafka_log_level"),
+        NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_num_slot,
+        NGX_HTTP_MAIN_CONF_OFFSET,
+        offsetof(ngx_http_json_log_filter_main_conf_t, kafka.log_level),
+        NULL
+    },
+    {
+        ngx_string("json_err_log_kafka_max_retries"),
+        NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_num_slot,
+        NGX_HTTP_MAIN_CONF_OFFSET,
+        offsetof(ngx_http_json_log_filter_main_conf_t, kafka.max_retries),
+        NULL
+    },
+    {
+        ngx_string("json_err_log_kafka_buffer_max_messages"),
+        NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_num_slot,
+        NGX_HTTP_MAIN_CONF_OFFSET,
+        offsetof(ngx_http_json_log_filter_main_conf_t, kafka.buffer_max_messages),
+        NULL
+    },
+    {
+        ngx_string("json_err_log_kafka_backoff_ms"),
+        NGX_HTTP_MAIN_CONF|NGX_CONF_TAKE1,
+        ngx_conf_set_msec_slot,
+        NGX_HTTP_MAIN_CONF_OFFSET,
+        offsetof(ngx_http_json_log_filter_main_conf_t, kafka.backoff_ms),
+        NULL
+    },
+    ngx_null_command
 };
 
 /* config preparation */
@@ -87,7 +194,7 @@ static ngx_http_module_t ngx_http_json_log_filter_module_ctx = {
     ngx_http_json_log_filter_init,             /* postconfiguration */
     ngx_http_json_log_filter_create_main_conf, /* create main configuration */
     NULL,                                      /* init main configuration */
-    NULL,                                      /* create server configuration */
+    ngx_http_json_log_filter_create_srv_conf,  /* create server configuration */
     NULL,                                      /* merge server configuration */
     ngx_http_json_log_filter_create_loc_conf,  /* create location configuration */
     NULL                                       /* merge location configuration */
@@ -100,7 +207,7 @@ ngx_module_t ngx_http_json_log_filter_module = {
     NGX_HTTP_MODULE,                       /* module type */
     NULL,                                  /* init master */
     NULL,                                  /* init module */
-    NULL,                                  /* init process */
+    ngx_http_json_log_filter_init_worker,  /* init process */
     NULL,                                  /* init thread */
     NULL,                                  /* exit thread */
     NULL,                                  /* exit process */
@@ -176,6 +283,194 @@ ngx_http_json_log_get_req_body_limit(ngx_http_request_t *r) {
     return lc->req_body_limit;
 }
 
+static void
+ngx_http_json_log_header_bad_request(ngx_http_request_t *r) {
+
+    ngx_http_json_log_srv_conf_t            *lc;
+    ngx_http_json_log_filter_main_conf_t    *mcf;
+    ngx_str_t                               filter_val;
+    char                                    *txt;
+    size_t                                  i, len;
+    ngx_json_log_output_location_t          *arr;
+    ngx_json_log_output_location_t          *location;
+    int                                     err;
+    size_t                     limit = HTTP_LOG_JSON_REQ_BODY_LIMIT_DEFAULT;
+    ngx_str_t                               msg_id;
+    ngx_str_t                  name = ngx_string("http_json_err_log_req");
+    ngx_str_t                           lcname;
+    ngx_http_variable_value_t           *vv;
+    ngx_uint_t                          varkey;
+    ngx_str_t                           payload;
+
+    lc = ngx_http_get_module_srv_conf(r, ngx_http_json_log_filter_module);
+    /* Location to eat http_json_log was not found */
+    if (!lc) {
+        return;
+    }
+
+    /* Bypass if number of location is empty */
+    if (!lc->locations->nelts) {
+        return;
+    }
+
+    if (r->header_in) {
+
+        limit = ngx_http_json_log_get_req_body_limit(r);
+        len = r->header_in->last - r->header_in->start;
+
+        if (len > limit) {
+            len = limit;
+        }
+
+        payload.data = ngx_pcalloc(r->pool, len);
+        if (payload.data) {
+
+            payload.len = len;
+            ngx_memcpy(payload.data, r->header_in->start, len);
+
+            lcname.len = name.len;
+            lcname.data = ngx_pcalloc(r->pool, name.len);
+            varkey = ngx_hash_strlow(lcname.data, name.data, name.len);
+
+            vv = ngx_http_get_variable(r, &lcname, varkey);
+            if (vv) {
+                ngx_http_json_log_set_variable_req_body(r,
+                        vv, (uintptr_t) &payload);
+            }
+        }
+    }
+
+    mcf = ngx_http_get_module_main_conf(r, ngx_http_json_log_filter_module);
+
+    arr = lc->locations->elts;
+    for (i = 0; i < lc->locations->nelts; ++i) {
+
+        location = &arr[i];
+
+        if (!location) {
+            break;
+        }
+
+        ngx_log_stderr(NGX_ERROR, "LOCATION=>%v", location);
+
+        /* Check filter result */
+        if (location->format.http_filter != NULL) {
+            if (ngx_http_complex_value(r,
+                        location->format.http_filter, &filter_val) != NGX_OK) {
+                /* WARN ? */
+                continue;
+            }
+
+            if (filter_val.len == 0
+                    || (filter_val.len == 1 && filter_val.data[0] == '0')) {
+                continue;
+            }
+        }
+
+        /* Get json text for items at this request */
+        /*TODO: cache format output dump */
+        txt = ngx_json_log_items_dump_text(NGX_JSON_LOG_HTTP, r,
+                location->format.items);
+        if (!txt) {
+            /* WARN ? */
+            continue;
+        }
+
+        /* Write to file */
+        if (location->type == NGX_JSON_LOG_SINK_FILE) {
+
+            if (!location->file) {
+                continue;
+            }
+
+            len = strlen(txt);
+            if (!len) {
+                ngx_log_error(NGX_LOG_EMERG, r->pool->log, 0, "Empty line");
+                continue;
+            }
+
+            if (ngx_json_log_write_sink_file(r->pool->log,
+                        location->file->fd, txt, len) == NGX_ERROR) {
+                ngx_log_error(NGX_LOG_EMERG, r->pool->log, 0, "Write Error!");
+            }
+            continue;
+        }
+
+        /* Write to kafka */
+        if (location->type == NGX_JSON_LOG_SINK_KAFKA) {
+
+            /* don't do anything if no kafka brokers to send */
+            if (! mcf->kafka.valid_brokers) {
+                continue;
+            }
+
+            if (location->kafka.rkt == NGX_CONF_UNSET_PTR ||
+                    !location->kafka.rkt)  {
+                /* configure and create topic */
+                location->kafka.rkt =
+                    ngx_json_log_kafka_topic_new(r->pool,
+                            mcf->kafka.rk, location->kafka.rktc,
+                            &location->location);
+            }
+
+            /* if failed to create topic */
+            if (!location->kafka.rkt) {
+                location->kafka.rkt = NGX_CONF_UNSET_PTR;
+                /* WARN ?*/
+                continue;
+            }
+
+            if (location->kafka.http_msg_id_var) {
+                ngx_http_complex_value(r,
+                        location->kafka.http_msg_id_var, &msg_id);
+#if (NGX_DEBUG)
+                ngx_log_error(NGX_LOG_DEBUG, r->pool->log, 0,
+                        "http_json_log: kafka msg-id:[%v] msg:[%s]",
+                        &msg_id, txt);
+#endif
+            }
+
+            /* FIXME : Reconnect support */
+            /* Send/Produce message. */
+            if ((err =  rd_kafka_produce(
+                            location->kafka.rkt,
+                            mcf->kafka.partition,
+                            RD_KAFKA_MSG_F_COPY,
+                            /* Payload and length */
+                            txt, strlen(txt),
+                            /* Optional key and its length */
+                            msg_id.data ? (const char *) msg_id.data: NULL,
+                            msg_id.len,
+                            /* Message opaque, provided in
+                             * delivery report callback as
+                             * msg_opaque. */
+                            NULL)) == -1) {
+
+                const char *errstr = rd_kafka_err2str(rd_kafka_errno2err(err));
+
+                ngx_log_error(NGX_LOG_ERR, r->pool->log, 0,
+                        "%% Failed to produce to topic %s "
+                        "partition %i: %s\n",
+                        rd_kafka_topic_name(location->kafka.rkt),
+                        mcf->kafka.partition,
+                        errstr);
+            } else {
+
+#if (NGX_DEBUG)
+
+                if (mcf) {
+                    ngx_log_error(NGX_LOG_DEBUG, r->pool->log, 0,
+                            "http_json_log: kafka msg:[%s] ERR:[%d] QUEUE:[%d]",
+                            txt, err, rd_kafka_outq_len(mcf->kafka.rk));
+                }
+#endif
+            }
+
+        } // if KAFKA type
+
+    } // for server
+}
+
 static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
 static ngx_int_t
 ngx_http_json_log_header_filter(ngx_http_request_t *r) {
@@ -190,6 +485,11 @@ ngx_http_json_log_header_filter(ngx_http_request_t *r) {
     ngx_http_variable_value_t           *vv;
     ngx_uint_t                          varkey;
     ngx_str_t                   name = ngx_string("http_json_log_resp_headers");
+
+    if (r->err_status == NGX_HTTP_BAD_REQUEST) {
+        ngx_http_json_log_header_bad_request(r);
+        return ngx_http_next_header_filter(r);
+    }
 
     if (!ngx_http_json_log_needs_header_filter()) {
         return ngx_http_next_header_filter(r);
@@ -238,7 +538,6 @@ ngx_http_json_log_header_filter(ngx_http_request_t *r) {
         header_copy->value.len = header[i].value.len;
 
     }
-
     if (headers->nelts < 1) {
         return ngx_http_next_header_filter(r);
     }
@@ -350,14 +649,23 @@ ngx_http_json_log_filter_init(ngx_conf_t *cf) {
 }
 
 static void *
-ngx_http_json_log_filter_create_main_conf(ngx_conf_t *cf) {
+ngx_http_json_log_filter_create_srv_conf(ngx_conf_t *cf) {
 
-    ngx_http_json_log_filter_main_conf_t  *conf;
+    ngx_http_json_log_srv_conf_t  *conf;
 
-    conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_json_log_filter_main_conf_t));
+    conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_json_log_srv_conf_t));
     if (conf == NULL) {
         return NULL;
     }
+
+    /* create an array for the output locations */
+    conf->locations = ngx_array_create(cf->pool, 1,
+            sizeof(ngx_json_log_output_location_t));
+
+
+    /* create the items array for formats */
+    conf->formats = ngx_array_create(cf->pool, 1,
+            sizeof(ngx_json_log_format_t));
 
     return conf;
 }
@@ -373,6 +681,182 @@ ngx_http_json_log_filter_create_loc_conf(ngx_conf_t *cf) {
     }
 
     conf->req_body_limit = HTTP_LOG_JSON_REQ_BODY_LIMIT_DEFAULT;
+
+    return conf;
+}
+
+/* Register the output location for the HTTP server config
+ * `json_log`
+ *
+ * Supported output destinations:
+ *
+ * file:   -> filesystem
+ * kafka:  -> kafka topic
+ */
+static char *
+ngx_http_json_log_srv_output(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) {
+
+    ngx_http_json_log_srv_conf_t         *lc = conf;
+    ngx_json_log_output_location_t       *new_location = NULL;
+    ngx_json_log_format_t                *format;
+    ngx_str_t                            *args = cf->args->elts;
+    ngx_str_t                            *value = NULL;
+    ngx_str_t                            *format_name;
+    ngx_uint_t                           found = 0;
+    size_t                               prefix_len;
+    size_t                               i;
+
+    if (! args) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                "Invalid argument for HTTP log JSON output location");
+        return NGX_CONF_ERROR;
+    }
+
+    /* Check if format exists by name */
+    format_name = &args[2];
+    format = lc->formats->elts;
+    for (i = 0; i < lc->formats->nelts; i++) {
+        if (ngx_strncmp(format_name->data, format[i].name.data,
+                    format[i].name.len) == 0) {
+            found = 1;
+            break;
+        }
+    }
+
+    /* Do not accept unknown format names */
+    if (!found)  {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                "http_json_log: Invalid format name [%V]",
+                format_name);
+        return NGX_CONF_ERROR;
+    }
+
+    value = &args[1];
+
+    if (NGX_JSON_LOG_HAS_FILE_PREFIX(value)) {
+        new_location = ngx_array_push(lc->locations);
+        new_location->type = NGX_JSON_LOG_SINK_FILE;
+        prefix_len = NGX_JSON_LOG_FILE_OUT_LEN;
+    }
+    else if (NGX_JSON_LOG_HAS_KAFKA_PREFIX(value)) {
+        new_location = ngx_array_push(lc->locations);
+        new_location->type = NGX_JSON_LOG_SINK_KAFKA;
+        prefix_len = NGX_JSON_LOG_KAFKA_OUT_LEN;
+
+    } else {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                "Invalid prefix [%v] for HTTP log JSON output location", value);
+        return NGX_CONF_ERROR;
+    }
+
+    if (!new_location) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                "Failed to add [%v] for HTTP log JSON output location", value);
+        return NGX_CONF_ERROR;
+    }
+
+    /* Saves location without prefix. */
+    new_location->location       = args[1];
+    new_location->location.len   -= prefix_len;
+    new_location->location.data  += prefix_len;
+    new_location->format         =  format[i];
+
+    /* If sink type is file, then try to open it and save */
+    if (new_location->type == NGX_JSON_LOG_SINK_FILE) {
+        new_location->file = ngx_conf_open_file(cf->cycle,
+                &new_location->location);
+    }
+
+    /* If sink type is kafka, then set topic config for this location */
+    if (new_location->type == NGX_JSON_LOG_SINK_KAFKA) {
+
+        /* create topic conf */
+        new_location->kafka.rktc = ngx_json_log_kafka_topic_conf_new(cf->pool);
+        if (! new_location->kafka.rktc) {
+            /* WARN ?*/
+            return NGX_CONF_ERROR;
+        }
+
+        /* configure topic acks */
+        ngx_json_log_kafka_topic_conf_set_str(cf->pool,
+                new_location->kafka.rktc,
+                conf_req_required_acks_key, &conf_zero_value);
+
+        /* Set global variable */
+        http_json_log_filter_has_kafka_locations = NGX_OK;
+
+#if nginx_version >= 1011000
+        ngx_http_compile_complex_value_t     ccv;
+        /*FIXME: Change this to an user's configured variable */
+        ngx_str_t                  msg_id_variable = ngx_string("$request_id");
+
+        /* Set variable for message id */
+        ngx_memzero(&ccv, sizeof(ngx_http_compile_complex_value_t));
+
+
+        ccv.cf = cf;
+        ccv.value = &msg_id_variable;
+        ccv.complex_value = ngx_pcalloc(cf->pool,
+                sizeof(ngx_http_complex_value_t));
+        if (ccv.complex_value == NULL) {
+            return NGX_CONF_ERROR;
+        }
+        if (ngx_http_compile_complex_value(&ccv) != NGX_OK) {
+            return NGX_CONF_ERROR;
+        }
+        new_location->kafka.http_msg_id_var = ccv.complex_value;
+#endif
+    }
+
+    return NGX_CONF_OK;
+}
+
+/* Initialized stuff per http_json_log worker.*/
+static ngx_int_t
+ngx_http_json_log_filter_init_worker(ngx_cycle_t *cycle) {
+
+    ngx_int_t rc = NGX_OK;
+    ngx_http_json_log_filter_main_conf_t  *conf =
+        ngx_http_cycle_get_module_main_conf(cycle,
+                ngx_http_json_log_filter_module);
+
+    /* From this point we just are init kafka stuff */
+    if (http_json_log_filter_has_kafka_locations == NGX_CONF_UNSET ) {
+        return NGX_OK;
+    }
+
+
+    rc = ngx_json_log_configure_kafka(cycle->pool, &conf->kafka);
+    if (rc != NGX_OK) {
+        return NGX_OK; //FIXME: What to do?
+    }
+
+    return NGX_OK;
+}
+
+static void *
+ngx_http_json_log_filter_create_main_conf(ngx_conf_t *cf) {
+
+    ngx_http_json_log_filter_main_conf_t  *conf;
+
+    conf = ngx_pcalloc(cf->pool, sizeof(ngx_http_json_log_filter_main_conf_t));
+    if (conf == NULL) {
+        return NULL;
+    }
+
+    /* kafka */
+    conf->kafka.rk                  = NULL;
+    conf->kafka.rkc                 = NULL;
+
+    /* default values */
+    conf->kafka.brokers             = ngx_array_create(cf->pool,
+            1 , sizeof(ngx_str_t));
+    conf->kafka.client_id.data      = NULL;
+    conf->kafka.compression.data    = NULL;
+    conf->kafka.log_level           = NGX_CONF_UNSET_UINT;
+    conf->kafka.max_retries         = NGX_CONF_UNSET_UINT;
+    conf->kafka.buffer_max_messages = NGX_CONF_UNSET_UINT;
+    conf->kafka.backoff_ms          = NGX_CONF_UNSET_UINT;
 
     return conf;
 }

--- a/src/ngx_http_json_log_module.c
+++ b/src/ngx_http_json_log_module.c
@@ -187,6 +187,7 @@ ngx_module_t ngx_http_json_log_module = {
 static ngx_int_t
 ngx_http_json_log_init_worker(ngx_cycle_t *cycle) {
 
+    ngx_int_t rc = NGX_OK;
     ngx_http_json_log_main_conf_t  *conf =
         ngx_http_cycle_get_module_main_conf(cycle, ngx_http_json_log_module);
 
@@ -195,7 +196,10 @@ ngx_http_json_log_init_worker(ngx_cycle_t *cycle) {
         return NGX_OK;
     }
 
-    ngx_json_log_configure_kafka(cycle->pool, &conf->kafka);
+    rc = ngx_json_log_configure_kafka(cycle->pool, &conf->kafka);
+    if (rc != NGX_OK) {
+        return NGX_OK; //FIXME: What to do?
+    }
 
     return NGX_OK;
 }
@@ -447,7 +451,7 @@ ngx_http_json_log_create_main_conf(ngx_conf_t *cf) {
 }
 
 /* Register a output location destination for the HTTP location config
- * `http_json_log_output`
+ * `json_log`
  *
  * Supported output destinations:
  *

--- a/src/ngx_http_json_log_module.h
+++ b/src/ngx_http_json_log_module.h
@@ -30,12 +30,20 @@
 
 #include <ngx_core.h>
 
+
 struct ngx_http_json_log_loc_conf_s {
     ngx_array_t                               *locations;
     ngx_array_t                               *formats;
 };
 
 typedef struct ngx_http_json_log_loc_conf_s   ngx_http_json_log_loc_conf_t;
+
+struct ngx_http_json_log_srv_conf_s {
+    ngx_array_t                               *locations;
+    ngx_array_t                               *formats;
+};
+
+typedef struct ngx_http_json_log_srv_conf_s     ngx_http_json_log_srv_conf_t;
 
 ngx_int_t
 ngx_http_json_log_needs_body_filter();

--- a/src/ngx_http_json_log_variables.c
+++ b/src/ngx_http_json_log_variables.c
@@ -65,6 +65,11 @@ static ngx_http_variable_t  ngx_http_json_log_variables_list[] = {
             ngx_http_json_log_set_variable_req_body,
             NULL,
             0, 0, 0
+        },
+        {   ngx_string("http_json_err_log_req"),
+            ngx_http_json_log_set_variable_req_body,
+            NULL,
+            0, 0, 0
         }
 };
 

--- a/src/ngx_json_log_kafka.c
+++ b/src/ngx_json_log_kafka.c
@@ -124,6 +124,7 @@ size_t ngx_json_log_kafka_add_brokers(ngx_pool_t *pool, rd_kafka_t *rk, ngx_arra
 
     rec = brokers->elts;
     for (size_t i = 0; i < brokers->nelts; ++i) {
+
         broker = &rec[i];
         value = ngx_json_log_str_dup(pool, broker);
 
@@ -136,6 +137,9 @@ size_t ngx_json_log_kafka_add_brokers(ngx_pool_t *pool, rd_kafka_t *rk, ngx_arra
                     "json_log: failed to configure \"%V\"", broker);
         }
     }
+
+
+
     return ret;
 }
 
@@ -258,6 +262,7 @@ ngx_json_log_configure_kafka(ngx_pool_t *pool,
     conf->rk = ngx_json_log_kafka_producer_new(
             pool,
             conf->rkc);
+
     if (! conf->rk) {
         return NGX_ERROR;
     }

--- a/src/ngx_json_log_text.h
+++ b/src/ngx_json_log_text.h
@@ -54,6 +54,10 @@ char *
 ngx_http_json_log_loc_format_block(ngx_conf_t *cf,
         ngx_command_t *cmd, void *conf);
 
+char *
+ngx_http_json_log_srv_format_block(ngx_conf_t *cf,
+        ngx_command_t *cmd, void *conf);
+
 #if nginx_version >= 1011002
 char *
 ngx_stream_json_log_srv_format_block(ngx_conf_t *cf,


### PR DESCRIPTION
###module: directives log_err_json_*###

* All log_err_json_* directives appply for server configuration for HTTP Bad Requests.

* Variable $http_json_err_log_req contains base64 encoded request payload.